### PR TITLE
This combined commit made several changes to the underlying library including

### DIFF
--- a/src/TeensyView.cpp
+++ b/src/TeensyView.cpp
@@ -107,7 +107,7 @@ TeensyView::TeensyView(uint8_t rst, uint8_t dc, uint8_t cs, uint8_t sck, uint8_t
 	csPin = cs;
 	sckPin = sck;
 	mosiPin = mosi;
-	clockRateSetting = 1000000;//Default rate of 1 MHz
+	clockRateSetting = 8000000;//Default rate of 8 MHz
 }
 
 //Set a non-default clock rate.  Run this before begin if alt rate is desired.

--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -45,6 +45,82 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 void TeensyView::spiSetup()
 {
 	// Initialize the pins:
+	// lets see if we have valid pins to use hardware support through spin. 
+	_pspin = NULL; 	// assume we will not use the hardware...
+
+#if defined(KINETISK) || defined(KINETISL) 
+	if (SPIN.pinIsMOSI(mosiPin) && SPIN.pinIsSCK(sckPin)) {
+		_pspin = &SPIN;
+	}
+	#ifdef SPIN1_OBJECT_CREATED			
+	else if (SPIN1.pinIsMOSI(mosiPin) && SPIN1.pinIsSCK(sckPin)) {
+		//Serial.println("SPI1 pins");
+		_pspin = &SPIN1;
+	}
+	#endif
+	#ifdef SPIN2_OBJECT_CREATED			
+	else if (SPIN2.pinIsMOSI(mosiPin) && SPIN2.pinIsSCK(sckPin)) {
+		//Serial.println("SPI2 pins");
+		_pspin = &SPIN2;
+	}
+	#endif
+
+	if (_pspin) {
+
+		_pspin->setMOSI(mosiPin);	// set the mosi pin. 
+		_pspin->setSCK(sckPin);
+
+		_pspin->begin();		// startup SPI
+		//Serial.println("Using SPIN");
+#ifdef KINETISK
+		_pkinetisk_spi = _pspin->kinetisk_spi(); // get handle on which SPI register set to use
+#else
+		_pkinetisl_spi = _pspin->kinetisl_spi(); // get handle on which SPI register set to use
+#endif		
+		// Now see if both cs and dc are chip select pins
+#ifdef KINETISK
+		if (_pspin->pinIsChipSelect(dcPin, csPin)) {
+			//Serial.println("CS and DC both hardware");
+			_pcs_data = _pspin->setCS(csPin);
+			_pcs_command = _pcs_data | _pspin->setCS(dcPin);
+			_csport = 0;	// make sure not to use it...
+		} else if (_pspin->pinIsChipSelect(dcPin)) {
+			//Serial.println("only DC is hardware");
+			_pcs_data = 0;
+			_pcs_command = _pcs_data | _pspin->setCS(dcPin);
+			pinMode(csPin, OUTPUT);
+			_csport    = portOutputRegister(digitalPinToPort(csPin));
+			_cspinmask = digitalPinToBitMask(csPin);
+			*_csport |= _cspinmask;
+		} else 
+#endif
+		{
+			//Serial.println("Not using Hardware CS pins");
+			_pcs_data = 0;
+			_pcs_command = 0;
+			pinMode(csPin, OUTPUT);
+			_csport    = portOutputRegister(digitalPinToPort(csPin));
+			_cspinmask = digitalPinToBitMask(csPin);
+			*_csport |= _cspinmask;
+			pinMode(dcPin, OUTPUT);
+			_dcport    = portOutputRegister(digitalPinToPort(dcPin));
+			_dcpinmask = digitalPinToBitMask(dcPin);
+			*_dcport |= _dcpinmask;
+			_dcpinAsserted = 0;
+		}
+
+	} else {
+		Serial.println("Not Valid SPI pins ");
+		pinMode(13, OUTPUT);
+		while (1) {
+			// Blink forever
+			digitalWrite(13, !digitalRead(13));
+			delay(200);
+		}
+
+	}
+#else
+	//Serial.println("Not Teensy 3.x or LC not using SPIN");
 	pinMode(csPin, OUTPUT);	// CS is an OUTPUT
 	digitalWrite(csPin, HIGH);	// Start CS High
 	
@@ -53,8 +129,7 @@ void TeensyView::spiSetup()
 	SPI.setSCK(sckPin);
 	
 	SPI.begin();
-	
-	
+#endif	
 }
 
 /** \brief Transfer a byte over SPI
@@ -64,10 +139,13 @@ void TeensyView::spiSetup()
 **/
 void TeensyView::spiTransfer(byte data)
 {
-	SPI.beginTransaction(SPISettings(clockRateSetting, MSBFIRST, SPI_MODE0));
+//	SPI.beginTransaction(SPISettings(clockRateSetting, MSBFIRST, SPI_MODE0));
     digitalWrite(csPin, LOW);
-	SPI.transfer(data);	
+    if (_pspin)
+    	_pspin->transfer(data);
+    else
+		SPI.transfer(data);	
     digitalWrite(csPin, HIGH);
-    SPI.endTransaction();
+//    SPI.endTransaction();
 }
 


### PR DESCRIPTION
Converted to use SPIN library

Convert to SPIN library to facilitate the ability to use the T3.x SPI
hardware queue for speed.  This allows me to use any of the SPI busses on
the Teensy.
Teensy 3.2 only has one SPI buss
But T3.5/3.6 both have three queues.

The code uses the hardware SPI queues which allows you to encode CS and DC state
changes into the SPI queue, such that we can run at full speed.  Earlier as with
the ILI9341 display I found using standard pin for CS did not impace performance
very much.  You gained the largest speed by encoding the DC

However since the default configuration for the Teensyview has the DC on
pin 5 which is not a hardware CS pin, I added support for this, while still
using the hardware queue, which appears to be working.  However it is
slightly slower.  For example a S
Also Added support for running on the Teensy LC at a faster speed as
a call to display on hardware DC pin was about 545us and on normal io pin
took about 555us.

Added support for running on T-LC.  Make it sort of emulate the T3.x
code that has queue.  But instead we at least try to full double buffer
the output to keep the queue busy.

Tested on TLC both SPI0 and SPI1
Tested on T3.6 on SPI0, SPI1, SPI2
Earlier tested on T3.2 on SPI0